### PR TITLE
Support timeout mocks on ie8

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -40,6 +40,15 @@
     return suite;
   };
 
+  /**
+   * Setting up timing functions to be able to be overridden. Certain browsers (Safari, IE 8, phantomjs) require
+   * this hack.
+   */
+  window.setTimeout = window.setTimeout;
+  window.setInterval = window.setInterval;
+  window.clearTimeout = window.clearTimeout;
+  window.clearInterval = window.clearInterval;
+
 
   /**
    * Build up the functions that will be exposed as the Jasmine


### PR DESCRIPTION
See http://www.adequatelygood.com/Replacing-setTimeout-Globally.html
for description of the problems and solutions.
Jasmine's `boot.js` [already has](https://github.com/pivotal/jasmine/blob/15f3d0e9d7841e46676ce991c95e00abc49b2eb2/lib/jasmine-core/boot/boot.js#L89-L95) this hack.

Fix #41
