### PR TITLE
fix: resolving spec names for suites without parents

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -60,6 +60,9 @@ var getAllSpecNames = function(topSuite) {
         childPointer = pointer[child.description] = {_: []};
         processSuite(child, childPointer);
       } else {
+        if (!pointer._) {
+          pointer._ = [];
+        }
         pointer._.push(child.description);
       }
     }


### PR DESCRIPTION
pointer._.push would throw undefined method for push - if parent topSuite would not contain any children suites
