### PR TITLE
Just load the jasmine methods directly from jasmine env

### DIFF
--- a/lib/boot.js
+++ b/lib/boot.js
@@ -51,69 +51,14 @@
 
 
   /**
-   * Build up the functions that will be exposed as the Jasmine
-   * public interface.
-   */
-  var jasmineInterface = {
-    describe: function(description, specDefinitions) {
-      return env.describe(description, specDefinitions);
-    },
-
-    xdescribe: function(description, specDefinitions) {
-      return env.xdescribe(description, specDefinitions);
-    },
-
-    ddescribe: function(description, specDefinitions) {
-      return focuseSuite(env, description, specDefinitions);
-    },
-
-    it: function(desc, func) {
-      return env.it(desc, func);
-    },
-
-    xit: function(desc, func) {
-      return env.xit(desc, func);
-    },
-
-    iit: function(desc, func) {
-      return focuseSpec(env, desc, func);
-    },
-
-    beforeEach: function(beforeEachFunction) {
-      return env.beforeEach(beforeEachFunction);
-    },
-
-    afterEach: function(afterEachFunction) {
-      return env.afterEach(afterEachFunction);
-    },
-
-    expect: function(actual) {
-      return env.expect(actual);
-    },
-
-    pending: function() {
-      return env.pending();
-    },
-
-    spyOn: function(obj, methodName) {
-      return env.spyOn(obj, methodName);
-    },
-
-    jsApiReporter: new jasmine.JsApiReporter({
-      timer: new jasmine.Timer()
-    })
-  };
-
-
-  /**
    * Add all of the Jasmine global/public interface to the proper
    * global, so a project can use the public interface directly.
    * For example, calling `describe` in specs instead of
    * `jasmine.getEnv().describe`.
    */
-  for (var property in jasmineInterface) {
-    if (jasmineInterface.hasOwnProperty(property)) {
-      window[property] = jasmineInterface[property];
+  for (var property in env) {
+    if (env.hasOwnProperty(property)) {
+      window[property] = env[property];
     }
   }
 


### PR DESCRIPTION
This should resolve #58.

Basically instead of creating a proxy to all the Jasmine methods, I just directly set all the methods on `env` to the `window` object.

I've manually tested this on my project for Jasmine `2.0.4` and `2.1.2` and it ran through all the tests fine.

Let me know if there are any concerns with this method.
