### PR TITLE
fix(adapter): cleanup error stack trace

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,21 +1,96 @@
-var formatFailedStep = function(step) {
-  var stack   = step.stack;
-  var message = step.message;
+/**
+ * Decision maker for whether a stack entry is considered relevant.
+ * @param  {String}  entry Error stack entry.
+ * @return {Boolean}       True if relevant, False otherwise.
+ */
+function isRelevantStackEntry(entry) {
+  // discard empty and falsy entries:
+  return (entry ? true : false) &&
+    // discard entries related to jasmine and karma-jasmine:
+    !/\/(jasmine-core|karma-jasmine)\//.test(entry) &&
+    // discard karma specifics, e.g. "at http://localhost:7018/karma.js:185"
+    !/\/(karma.js|context.html):/.test(entry);
+}
 
-  if (stack) {
-    // remove the trailing dot
-    var firstLine = stack.substring(0, stack.indexOf('\n') - 1);
+/**
+ * Returns relevant stack entries.
+ * @param  {String} stack Complete error stack trace.
+ * @return {Array}        A list of relevant stack entries.
+ */
+function getRelevantStackFrom(stack) {
+  var relevantStack = [];
 
-    if (message && message.indexOf(firstLine) === -1) {
-      stack = message +'\n'+ stack;
+  stack = stack.split('\n');
+
+  for (var i = 0; i < stack.length; i += 1) {
+    if (isRelevantStackEntry(stack[i])) {
+      relevantStack.push(stack[i]);
     }
-
-    // remove jasmine stack entries
-    return stack.replace(/\n.+jasmine\.js\?\w*\:.+(?=(\n|$))/g, '');
   }
 
-  return message;
-};
+  return relevantStack;
+}
+
+/**
+ * Custom formatter for a failed step.
+ *
+ * Different browsers report stack trace in different ways. This function
+ * attempts to provide a concise, relevant error message by removing the
+ * unnecessary stack traces coming from the testing framework itself as well
+ * as possible repetition.
+ *
+ * @see    https://github.com/karma-runner/karma-jasmine/issues/60
+ * @param  {Object} step Step object with stack and message properties.
+ * @return {String}      Formatted step.
+ */
+function formatFailedStep(step) {
+  // Safari seems to have no stack trace,
+  // so we just return the error message:
+  if (!step.stack) { return step.message; }
+
+  var relevantMessage = [];
+  var relevantStack = [];
+  var dirtyRelevantStack = getRelevantStackFrom(step.stack);
+
+  // PhantomJS returns multiline error message for errors coming from specs
+  // (for example when calling a non-existing function). This error is present
+  // in both `step.message` and `step.stack` at the same time, but stack seems
+  // preferable, so we iterate relevant stack, compare it to message:
+  for (var i = 0; i < dirtyRelevantStack.length; i += 1) {
+    if (step.message && step.message.indexOf(dirtyRelevantStack[i]) === -1) {
+      // Stack entry is not in the message,
+      // we consider it to be a relevant stack:
+      relevantStack.push(dirtyRelevantStack[i]);
+    } else {
+      // Stack entry is already in the message,
+      // we consider it to be a suitable message alternative:
+      relevantMessage.push(dirtyRelevantStack[i]);
+    }
+  }
+
+  // In most cases the above will leave us with an empty message...
+  if (relevantMessage.length === 0) {
+    // Let's reuse the original message:
+    relevantMessage.push(step.message);
+
+    // Now we probably have a repetition case where:
+    // relevantMessage: ["Expected true to be false."]
+    // relevantStack:   ["Error: Expected true to be false.", ...]
+    if (relevantStack[0].indexOf(step.message) !== -1) {
+      // The message seems preferable, so we remove the first value from
+      // the stack to get rid of repetition :
+      relevantStack.shift();
+    }
+  }
+
+  // Example output:
+  // --------------------
+  // Chrome 40.0.2214 (Mac OS X 10.9.5) xxx should return false 1 FAILED
+  //    Expected true to be false
+  //    at /foo/bar/baz.spec.js:22:13
+  //    at /foo/bar/baz.js:18:29
+  return relevantMessage.concat(relevantStack).join('\n');
+}
 
 
 var indexOf = function(collection, item) {


### PR DESCRIPTION
# Proposal for #60

Replaces the following:

```Bash
Chrome 40.0.2214 (Mac OS X 10.9.5) xxx should return false 1 FAILED
	Expected true to be false.
	Error: Expected true to be false.
        at stack (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1441:17)
        at buildExpectationResult (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1411:14)
        at Spec.Env.expectationResultFactory (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:533:18)
        at Spec.addExpectationResult (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:293:34)
        at Expectation.addExpectationResult (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:477:21)
        at Expectation.toBe (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1365:12)
        at /foo/bar/baz.spec.js:23:29
        at /foo/bar/baz.js:18:20
```

with a concise and useful:

```Bash
Chrome 40.0.2214 (Mac OS X 10.9.5) xxx should return false 1 FAILED
	Expected true to be false.
        at /foo/bar/baz.spec.js:23:29
        at /foo/bar/baz.js:18:20
```

Also handles multiline error message in PhantomJS:

```Bash
PhantomJS 1.9.8 (Mac OS X) xxx should return false 1 FAILED
	TypeError: 'undefined' is not a function (evaluating 'zzz(function (res) {
	                expect(res).toBe(false);
	                done();
	            })')
	    at /foo/bar/baz.spec.js:31
```

Note that karma specifics, such as:

```Bash
	    ...
	    at http://localhost:7018/karma.js:185
	    at http://localhost:7018/context.html:1229
```

have been removed. Maybe we should keep context.html? Thoughts?