### PR TITLE
use jasmine Timer for timing, and also send fullName to the karma result

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -312,7 +312,11 @@ function createStartFn(karma, jasmineEnv) {
   return function () {
     jasmineEnv = jasmineEnv || window.jasmine.getEnv();
 
-    jasmineEnv.addReporter(new KarmaReporter(karma, jasmineEnv, {timer: new jasmine.Timer()}));
+    var options = {
+      timer: (window.jasmine ? new window.jasmine.Timer() : {now : function() {return new Date().getTime();}})
+    };
+
+    jasmineEnv.addReporter(new KarmaReporter(karma, jasmineEnv, options));
     jasmineEnv.execute();
   };
 }

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -141,7 +141,7 @@ function getAllSpecNames(topSuite) {
 /**
  * Very simple reporter for Jasmine.
  */
-function KarmaReporter(tc, jasmineEnv) {
+function KarmaReporter(tc, jasmineEnv, options) {
 
   var currentSuite = new SuiteNode();
 
@@ -199,7 +199,7 @@ function KarmaReporter(tc, jasmineEnv) {
 
 
   this.specStarted = function (specResult) {
-    specResult.startTime = new Date().getTime();
+    specResult.startTime = options.timer.now();
   };
 
 
@@ -208,12 +208,13 @@ function KarmaReporter(tc, jasmineEnv) {
 
     var result = {
       description : specResult.description,
+      fullName    : specResult.fullName,
       id          : specResult.id,
       log         : [],
       skipped     : skipped,
       success     : specResult.failedExpectations.length === 0,
       suite       : [],
-      time        : skipped ? 0 : new Date().getTime() - specResult.startTime
+      time        : skipped ? 0 : options.timer.now() - specResult.startTime
     };
 
     // generate ordered list of (nested) suite names
@@ -311,7 +312,7 @@ function createStartFn(karma, jasmineEnv) {
   return function () {
     jasmineEnv = jasmineEnv || window.jasmine.getEnv();
 
-    jasmineEnv.addReporter(new KarmaReporter(karma, jasmineEnv));
+    jasmineEnv.addReporter(new KarmaReporter(karma, jasmineEnv, {timer: new jasmine.Timer()}));
     jasmineEnv.execute();
   };
 }

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -20,7 +20,7 @@ describe('jasmine adapter', function(){
       env = jasmine.getEnv();
 
       karma = new Karma(new MockSocket(), null, null, null, {search: ''});
-      reporter = new KarmaReporter(karma, env);
+      reporter = new KarmaReporter(karma, env, {timer: {now: function() {return new Date().getTime();}}});
 
       spyOn(karma, 'result');
 


### PR DESCRIPTION
The timer might change to provide higher resolution timing for performance tests - as per this pull request: https://github.com/jasmine/jasmine/pull/777

The fullName is sent so we'll be able to easily distinguish between tests, for comparing performance to previous runs - as per this grunt task: https://github.com/Malkiz/grunt-performance-comparer