### PR TITLE
fix(adapter): remove error message from stack prior to processing stack

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -53,7 +53,12 @@ function formatFailedStep(step) {
 
   var relevantMessage = [];
   var relevantStack = [];
-  var dirtyRelevantStack = getRelevantStackFrom(step.stack);
+
+  // Remove the message prior to processing the stack to prevent issues like
+  // https://github.com/karma-runner/karma-jasmine/issues/79
+  var stack = step.stack.replace('Error: ' + step.message, '');
+
+  var dirtyRelevantStack = getRelevantStackFrom(stack);
 
   // PhantomJS returns multiline error message for errors coming from specs
   // (for example when calling a non-existing function). This error is present

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -201,6 +201,18 @@ describe('jasmine adapter', function(){
       expect( formatFailedStep(step) ).toBe( 'MESSAGE' );
     });
 
+
+    it('should properly format message containing new-line characters', function(){
+      // FF does not have the message in the stack trace
+
+      var step = {
+        passed  : false,
+        message : 'Jasmine fail\nmessage',
+        stack   : 'Error: Jasmine fail\nmessage\n@file.js:123'
+      };
+
+      expect( formatFailedStep(step) ).toMatch( 'Jasmine fail\nmessage\n@file.js:123' );
+    });
   });
 
 


### PR DESCRIPTION
The displayed error message is incorrectly formatted when the message contains new-line characters, since getRelevantStackFrom() splits the stack on new-line characters.

This pull request addresses issue #79 