### PR TITLE
[v1] fix: Remove getCurrentTransport.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -31,26 +31,6 @@ var indexOf = function(collection, item) {
 };
 
 
-// TODO(vojta): Karma might provide this
-var getCurrentTransport = function() {
-  var parentWindow = window.opener || window.parent;
-  var location = parentWindow.location;
-  var hostname = 'http://' + location.host;
-
-  if (!location.port) {
-    hostname += ':80';
-  }
-
-  // Probably running in debug.html (there's no socket.io),
-  // or in debug mode with socket.io but no socket on this host.
-  if (!parentWindow.io || !parentWindow.io.sockets[hostname]) {
-    return null;
-  }
-
-  return parentWindow.io.sockets[hostname].transport.name;
-};
-
-
 /**
  * Very simple reporter for jasmine
  */
@@ -87,15 +67,7 @@ var KarmaReporter = function(tc) {
   };
 
   this.reportRunnerStarting = function(runner) {
-    var transport = getCurrentTransport();
-    var specNames = null;
-
-    // This structure can be pretty huge and it blows up socket.io connection, when polling.
-    // https://github.com/LearnBoost/socket.io-client/issues/569
-    if (transport === 'websocket' || transport === 'flashsocket') {
-      specNames = getAllSpecNames(runner.topLevelSuites());
-    }
-
+    var specNames = getAllSpecNames(runner.topLevelSuites());
     tc.info({total: runner.specs().length, specs: specNames});
   };
 


### PR DESCRIPTION
>  Do not merge into master! This is is only needed for the `0.1` branch.

This is not needed anymore for socket.io 1.3.

Ref https://github.com/karma-runner/karma/pull/1404

**Update**: This needs to bump the dependency of karma, to ensure that it uses the version with the new  socket.io (probably `0.14.0`) as otherwise these change could lead to issues with the older versions.