### PR TITLE
Fix #102 - --grep option only works if it's the first argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
-  - "0.8"
+  - "0.10"
+  - "0.12"
+  - "4.0"
+  - "5.0"
+  - "stable"
 
 # Make sure we have new NPM.
 before_install:

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.6",
     "karma": "",
-    "karma-jasmine": "~0.1.0",
-    "karma-chrome-launcher": "~0.1.0",
+    "karma-jasmine": "~0.3.0",
+    "karma-chrome-launcher": "~0.2.0",
     "karma-firefox-launcher": "~0.1.0",
-    "grunt-karma": "~0.8.0",
+    "grunt-karma": "~0.12.0",
     "grunt-auto-release": "~0.0.2",
     "grunt-npm": "~0.0.2",
     "grunt-bump": "~0.0.7",
-    "jasmine-core": "~2.1.0"
+    "jasmine-core": "~2.3.4"
   },
   "peerDependencies": {
     "jasmine-core": "*"

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -258,14 +258,27 @@ function KarmaReporter(tc, jasmineEnv) {
  * @return {string} The value of grep option by default empty string
  */
 var getGrepOption = function(clientArguments) {
-  var clientArgString = clientArguments || '';
+  var grepRegex = /^--grep=(.*)$/;
 
   if (Object.prototype.toString.call(clientArguments) === '[object Array]') {
-    clientArgString = clientArguments.join('=');
-  }
+    var indexOfGrep = clientArguments.indexOf('--grep');
 
-  var match = /--grep=(.*)/.exec(clientArgString);
-  return match ? match[1] : '';
+    if(indexOfGrep !== -1) {
+      return clientArguments[indexOfGrep + 1];
+    }
+
+    return clientArguments
+            .filter(function(arg) {
+              return grepRegex.test(arg);
+            })
+            .map(function(arg) {
+              return arg.replace(grepRegex, '$1');
+            })[0] || '';
+  } else if (typeof clientArguments === 'string') {
+    var match = /--grep=([^=]+)/.exec(clientArguments);
+
+    return match ? match[1] : '';
+  }
 };
 
 /**

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -51,7 +51,7 @@ describe('jasmine adapter', function(){
 
 
     it('should report all spec names', function(){
-      spyOn(karma, 'info').andCallFake(function(info){
+      spyOn(karma, 'info').and.callFake(function(info){
         expect(info.total).toBe(2);
         expect(info.specs).toEqual({
           one: {
@@ -81,7 +81,7 @@ describe('jasmine adapter', function(){
 
 
     it('should report success result', function(){
-      karma.result.andCallFake(function(result){
+      karma.result.and.callFake(function(result){
         expect(result.id).toBe(spec.id);
         expect(result.description).toBe('contains spec with an expectation');
         expect(result.suite).toEqual([ 'Parent Suite', 'Child Suite' ]);
@@ -97,7 +97,7 @@ describe('jasmine adapter', function(){
 
 
     it('should report fail result', function(){
-      karma.result.andCallFake(function(result){
+      karma.result.and.callFake(function(result){
         expect(result.success).toBe(false);
         expect(result.log.length).toBe(1);
       });
@@ -123,7 +123,7 @@ describe('jasmine adapter', function(){
         '    at /foo/bar/baz.spec.js:23:29\n' +
         '    at /foo/bar/baz.js:18:20\n';
 
-      karma.result.andCallFake(function(result){
+      karma.result.and.callFake(function(result){
         expect(result.log).toEqual([
           'Expected true to be false.\n' +
           '    at /foo/bar/baz.spec.js:23:29\n' +
@@ -151,7 +151,7 @@ describe('jasmine adapter', function(){
         '    at Expectation.toBe (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1365:12)\n';
 
 
-      karma.result.andCallFake(function(result){
+      karma.result.and.callFake(function(result){
         expect(result.log).toEqual([
           'Expected true to be false.\n' +
           '    at stack (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1441:17)\n' +
@@ -171,7 +171,7 @@ describe('jasmine adapter', function(){
     });
 
     it('should remove special top level suite from result', function () {
-      karma.result.andCallFake(function(result){
+      karma.result.and.callFake(function(result){
         expect(result.suite).toEqual([ 'Child Suite' ]);
       });
 
@@ -191,11 +191,11 @@ describe('jasmine adapter', function(){
     it('should report time for every spec', function(){
       var counter = 3;
 
-      spyOn(Date.prototype, 'getTime').andCallFake(function(){
+      spyOn(Date.prototype, 'getTime').and.callFake(function(){
         return counter+=1;
       });
 
-      karma.result.andCallFake(function(result){
+      karma.result.and.callFake(function(result){
         expect(result.time).toBe(1); // 4 - 3
       });
 
@@ -296,17 +296,17 @@ describe('jasmine adapter', function(){
     });
 
     it('should split by newline and return all values for which isExternalStackEntry returns true', function () {
-      isExternalStackEntry = jasmine.createSpy('isExternalStackEntry').andReturn(true);
+      isExternalStackEntry = jasmine.createSpy('isExternalStackEntry').and.returnValue(true);
       expect(getRelevantStackFrom('a\nb\nc')).toEqual(['a', 'b', 'c']);
     });
 
     it('should return the all stack entries if every entry is irrelevant', function () {
-      isExternalStackEntry = jasmine.createSpy('isExternalStackEntry').andReturn(false);
+      isExternalStackEntry = jasmine.createSpy('isExternalStackEntry').and.returnValue(false);
       expect(getRelevantStackFrom('a\nb\nc')).toEqual(['a', 'b', 'c']);
     });
 
     it('should return only the relevant stack entries if the stack contains relevant entries', function () {
-      isExternalStackEntry = jasmine.createSpy('isExternalStackEntry').andCallFake(function (entry) {
+      isExternalStackEntry = jasmine.createSpy('isExternalStackEntry').and.callFake(function (entry) {
         return entry !== 'b';
       });
       expect(getRelevantStackFrom('a\nb\nc')).toEqual(['a', 'c']);
@@ -358,7 +358,7 @@ describe('jasmine adapter', function(){
         args: ['--grep', 'test']
       };
       var specMock = {
-        getFullName: jasmine.createSpy('getFullName').andReturn('test')
+        getFullName: jasmine.createSpy('getFullName').and.returnValue('test')
       };
 
       createSpecFilter(karmaConfMock, jasmineEnvMock);

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -326,6 +326,10 @@ describe('jasmine adapter', function(){
     it('should get grep option from args if args is string', function() {
       expect(getGrepOption('--grep=test')).toEqual('test');
     });
+
+    it('should get grep option from args if second arg', function() {
+      expect(getGrepOption(['--arg1', 'value1', '--grep', 'grepValue'])).toEqual('grepValue');
+    });
   });
 
 


### PR DESCRIPTION
I had to make additional changes to this to make it work:

1. Had to update the test suite to work with newer jasmine, karma, etc. in order to install it locally or in TravisCI for testing purposes
2. Updated the adapter test to use jasmine 2 syntax (`.and.returnValue` instead of `.andReturn`, for example)
3. Had to specify Firefox as an addon in the .travis.yml file to get Firefox loaded
4. Had to change the node version in .travis.yml (switched to 0.12; I don't know if you want it to be a newer version or if you want to keep using the 0.x branch)

The changes I made:

1. If it's an array, process it as such instead of joining it into a string. This allows us to more cleanly match the --grep option and return its value
2. If it's a string, use the solution I documented in issue #102 (matching up to an equal sign)