### PR TITLE
Fixed fatal error thrown in IE 8

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -251,7 +251,8 @@ function KarmaReporter (tc, jasmineEnv) {
 var getGrepOption = function (clientArguments) {
   var grepRegex = /^--grep=(.*)$/
 
-  if (Object.prototype.toString.call(clientArguments) === '[object Array]') {
+  // IE 8 may not always have the polyfilled indexOf method
+  if (clientArguments.indexOf && Object.prototype.toString.call(clientArguments) === '[object Array]') {
     var indexOfGrep = clientArguments.indexOf('--grep')
 
     if (indexOfGrep !== -1) {


### PR DESCRIPTION
When a grep argument is not passed in, clientArguments can be an
object that does not have access to the polyfilled indexOf
method. Check for indexOf to avoid fatal IE8 errors in this
scenario.