### PR TITLE
chore: fix integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 tmp/
 lib/adapter.js
+integration-tests/

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,4 +1,4 @@
 PKG_FILE="$PWD/$(npm pack)"
 git clone https://github.com/karma-runner/integration-tests.git --depth 1
 cd integration-tests
-./run.sh "jasmine" $PKG_FILE
+./run.sh -g "jasmine" $PKG_FILE


### PR DESCRIPTION
Now ./integration-test.sh runs all integration tests because pass incorrect parameters to ./run.sh and also this tests does not run on builded.zip.

Current commit fix this. But we **also should fix** `./run.sh` because there we set `set -e`
and exit on line `  MATCH_COUNT=$(echo $DIR | egrep -c -e "$GREP")` because if egrep does not match line it exits with status code 1