### PR TITLE
Add option to use original jasmine step.message always in error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ module.exports = function(config) {
 }
 ```
 
+If you are having issues with error messages not properly being displayed, you can set the plugin to use the original jasmine's step error.message
+```js
+module.exports = function(config) {
+  config.set({
+    ...
+    client: {
+      jasmine: {
+        useStepErrorMessage: true
+      }
+    }
+  })
+}
+```
 ----
 
 For more information on Karma see the [homepage].

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -57,9 +57,11 @@ function getRelevantStackFrom (stack) {
  *
  * @see    https://github.com/karma-runner/karma-jasmine/issues/60
  * @param  {Object} step Step object with stack and message properties.
+ * @param  {Boolean} useStepErrorMessage Whether to use the steps message as the 
+ *   relevant error message or the one from the stack, defaults to from the stack
  * @return {String}      Formatted step.
  */
-function formatFailedStep (step) {
+function formatFailedStep (step, useStepErrorMessage) {
   // Safari seems to have no stack trace,
   // so we just return the error message:
   if (!step.stack) { return step.message }
@@ -82,7 +84,7 @@ function formatFailedStep (step) {
       // Stack entry is not in the message,
       // we consider it to be a relevant stack:
       relevantStack.push(dirtyRelevantStack[i])
-    } else {
+    } else if (!useStepErrorMessage) {
       // Stack entry is already in the message,
       // we consider it to be a suitable message alternative:
       relevantMessage.push(dirtyRelevantStack[i])
@@ -157,6 +159,8 @@ function getAllSpecNames (topSuite) {
  */
 function KarmaReporter (tc, jasmineEnv) {
   var currentSuite = new SuiteNode()
+
+  var jasmineOptions = tc.config.jasmine || {}
 
   /**
    * @param suite
@@ -235,7 +239,7 @@ function KarmaReporter (tc, jasmineEnv) {
     if (!result.success) {
       var steps = specResult.failedExpectations
       for (var i = 0, l = steps.length; i < l; i++) {
-        result.log.push(formatFailedStep(steps[i]))
+        result.log.push(formatFailedStep(steps[i], jasmineOptions.useStepErrorMessage))
       }
     }
 


### PR DESCRIPTION
Certain errors being thrown by a library in my code contains part of a stack trace in the full error message, causing the step.message (with its important extra data) to get replaced with the not helpful line found in the stack trace.  I added an option to always use the original step.message and made it default to using the current method of using the message found in the stack trace.

Option can be set by:

``` js
module.exports = function(config) {
  config.set({
    ....
    client: {
      jasmine: {
        useStepErrorMessage: true
      }
    }
  }
}
```

Running this successfully in my fork now but it would be nice to have it merged in case anyone else runs into this rather specific issue.
