### PR TITLE
Allow regexes to grep argument

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -276,7 +276,7 @@ var getGrepOption = function (clientArguments) {
  * @param {Object} options Spec filter options
  */
 var KarmaSpecFilter = function (options) {
-  var filterString = options && options.filterString() && options.filterString().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+  var filterString = options && options.filterString()
   var filterPattern = new RegExp(filterString)
 
   this.matches = function (specName) {


### PR DESCRIPTION
I'm not sure why special characters were being escaped here, it would make grep much more powerful if you could use regexes.

For instance, if I have a class named `Foo` and I want to run all its tests which by convention would live in `foo_spec.js` and have a top-level `describe('Foo')`. It would be useful if I could use some regex like `karma run -- --grep='^Foo( |$)'`. This would run exactly the tests I described, and wouldn't run anything that has `Foo` later on in the description and wouldn't run a different class named `FooBar`, etc.
