### PR TITLE
feat: Propagate errors thrown in afterAll blocks

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -170,6 +170,18 @@ function KarmaReporter (tc, jasmineEnv) {
     return suite.description === 'Jasmine_TopLevel_Suite'
   }
 
+  function handleGlobalErrors (result) {
+    if (result.failedExpectations && result.failedExpectations.length) {
+      var message = 'An error was thrown in afterAll'
+      var steps = result.failedExpectations
+      for (var i = 0, l = steps.length; i < l; i++) {
+        message += '\n' + formatFailedStep(steps[i])
+      }
+
+      tc.error(message)
+    }
+  }
+
   /**
    * Jasmine 2.0 dispatches the following events:
    *
@@ -191,6 +203,10 @@ function KarmaReporter (tc, jasmineEnv) {
 
   this.jasmineDone = function (result) {
     result = result || {}
+
+    // Any errors in top-level afterAll blocks are given here.
+    handleGlobalErrors(result)
+
     tc.complete({
       order: result.order,
       coverage: window.__coverage__
@@ -209,6 +225,10 @@ function KarmaReporter (tc, jasmineEnv) {
     if (result.description !== currentSuite.name) {
       return
     }
+
+    // Any errors in afterAll blocks are given here, except for top-level
+    // afterAll blocks.
+    handleGlobalErrors(result)
 
     currentSuite = currentSuite.parent
   }

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -145,6 +145,23 @@ describe('jasmine adapter', function () {
       expect(karma.result).toHaveBeenCalled()
     })
 
+    it('should report errors in afterAll blocks', function () {
+      spyOn(karma, 'complete')
+      spyOn(karma, 'error')
+
+      var result = {
+        failedExpectations: []
+      }
+
+      reporter.jasmineDone(result)
+      expect(karma.error).not.toHaveBeenCalled()
+
+      result.failedExpectations.push({})
+
+      reporter.jasmineDone(result)
+      expect(karma.error).toHaveBeenCalled()
+    })
+
     it('should report executedExpectCount as sum of passed and failed expectations', function () {
       karma.result.and.callFake(function (result) {
         expect(result.executedExpectationsCount).toBe(2)


### PR DESCRIPTION
If an error is thrown in an afterAll block, it needs to be handled
specially since the error isn't attached to a specific spec.  This
change won't fail any specific test, but will cause a general failure
which will still cause overall run failure.

Closes #161