### PR TITLE
Remove incorrect function and its call.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -163,14 +163,6 @@ function KarmaReporter (tc, jasmineEnv) {
   var _Date = Date
   var startTimeCurrentSpec = new _Date().getTime()
 
-  /**
-   * @param suite
-   * @returns {boolean} Return true if it is system jasmine top level suite
-   */
-  function isTopLevelSuite (suite) {
-    return suite.description === 'Jasmine_TopLevel_Suite'
-  }
-
   function handleGlobalErrors (result) {
     if (result.failedExpectations && result.failedExpectations.length) {
       var message = 'An error was thrown in afterAll'
@@ -215,9 +207,7 @@ function KarmaReporter (tc, jasmineEnv) {
   }
 
   this.suiteStarted = function (result) {
-    if (!isTopLevelSuite(result)) {
-      currentSuite = currentSuite.addChild(result.description)
-    }
+    currentSuite = currentSuite.addChild(result.description)
   }
 
   this.suiteDone = function (result) {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -245,23 +245,6 @@ describe('jasmine adapter', function () {
       expect(karma.result).toHaveBeenCalled()
     })
 
-    it('should remove special top level suite from result', function () {
-      karma.result.and.callFake(function (result) {
-        expect(result.suite).toEqual(['Child Suite'])
-      })
-
-      reporter.suiteStarted({
-        id: 'suite0',
-        description: 'Jasmine_TopLevel_Suite'
-      })
-      reporter.suiteStarted(suite.result)
-      spec.result.failedExpectations.push({stack: 'stack'})
-
-      reporter.specDone(spec.result)
-
-      expect(karma.result).toHaveBeenCalled()
-    })
-
     it('should report time for every spec', function () {
       var counter = 3
 


### PR DESCRIPTION
The string tested in the function isTopLevelSuite() is not used in jasmine. The
correct string would be Jasmine__TopLevel__Suite (two underscores). So the function
always returns false, and we negate it at the call site, to the child is always
added. That's the correct behavior because we already have a root node matching
the Jasmine top level suite. The test and the function is unnecessary.