### PR TITLE
Add support for Jasmine 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ module.exports = function(config) {
       jasmine: {
         random: true,
         seed: '4321',
-        stopOnFailure: true
+        stopOnFailure: true,
+        failFast: true
       }
     }
   })

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "grunt-eslint": "^18.0.0",
     "grunt-karma": "2.x",
     "grunt-npm": "0.0.2",
-    "jasmine-core": "~2.4.1",
     "karma": "2.x || ",
+    "jasmine-core": "~3.0.0",
     "karma-chrome-launcher": "1.x || ~0.2.2",
     "karma-firefox-launcher": "1.x || ~0.1.7",
     "load-grunt-tasks": "^3.4.1"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {},
   "devDependencies": {
+    "conventional-changelog": "1.1.7",
+    "conventional-changelog-core": "1.9.3",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -238,14 +238,14 @@ function KarmaReporter (tc, jasmineEnv) {
   }
 
   this.specDone = function (specResult) {
-    var skipped = specResult.status === 'disabled' || specResult.status === 'pending'
+    var skipped = specResult.status === 'disabled' || specResult.status === 'pending' || specResult.status === 'excluded'
 
     var result = {
       description: specResult.description,
       id: specResult.id,
       log: [],
       skipped: skipped,
-      disabled: specResult.status === 'disabled',
+      disabled: specResult.status === 'disabled' || specResult.status === 'excluded',
       pending: specResult.status === 'pending',
       success: specResult.failedExpectations.length === 0,
       suite: [],
@@ -347,6 +347,7 @@ function createStartFn (karma, jasmineEnv) {
     jasmineEnv = jasmineEnv || window.jasmine.getEnv()
 
     setOption(jasmineConfig.stopOnFailure, jasmineEnv.throwOnExpectationFailure)
+    setOption(jasmineConfig.failFast, jasmineEnv.stopOnSpecFailure)
     setOption(jasmineConfig.seed, jasmineEnv.seed)
     setOption(jasmineConfig.random, jasmineEnv.randomizeTests)
 
@@ -355,7 +356,7 @@ function createStartFn (karma, jasmineEnv) {
   }
 
   function setOption (option, set) {
-    if (option != null) {
+    if (option != null && typeof set === 'function') {
       set(option)
     }
   }


### PR DESCRIPTION
Jasmine 3.0 uses a status of `excluded` instead of `disabled` and has a new option to `failFast`.

Since Jasmine 3.0 also defaults to running specs in random order, I also had to update a few of the existing specs to use `spyOn` so the spies get cleaned up and don't pollute other specs.