### PR TITLE
fix(time): report correct time since Jasmine v2.9.0

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -161,6 +161,7 @@ function KarmaReporter (tc, jasmineEnv) {
   // Save link on native Date object
   // because user can mock it
   var _Date = Date
+  var startTimeCurrentSpec = new _Date().getTime();
 
   /**
    * @param suite
@@ -234,7 +235,7 @@ function KarmaReporter (tc, jasmineEnv) {
   }
 
   this.specStarted = function (specResult) {
-    specResult.startTime = new _Date().getTime()
+    startTimeCurrentSpec = new _Date().getTime()
   }
 
   this.specDone = function (specResult) {
@@ -249,7 +250,7 @@ function KarmaReporter (tc, jasmineEnv) {
       pending: specResult.status === 'pending',
       success: specResult.failedExpectations.length === 0,
       suite: [],
-      time: skipped ? 0 : new _Date().getTime() - specResult.startTime,
+      time: skipped ? 0 : new _Date().getTime() - startTimeCurrentSpec,
       executedExpectationsCount: specResult.failedExpectations.length + specResult.passedExpectations.length
     }
 

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -161,7 +161,7 @@ function KarmaReporter (tc, jasmineEnv) {
   // Save link on native Date object
   // because user can mock it
   var _Date = Date
-  var startTimeCurrentSpec = new _Date().getTime();
+  var startTimeCurrentSpec = new _Date().getTime()
 
   /**
    * @param suite
@@ -234,7 +234,7 @@ function KarmaReporter (tc, jasmineEnv) {
     currentSuite = currentSuite.parent
   }
 
-  this.specStarted = function (specResult) {
+  this.specStarted = function () {
     startTimeCurrentSpec = new _Date().getTime()
   }
 

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -253,14 +253,6 @@ describe('jasmine adapter', function () {
     it('should report time for every spec', function () {
       var counter = 3
 
-      function copySpecResult() {
-        var copy = {}
-        for(var i in spec.result) {
-          copy[i] = spec.result[i]
-        }
-        return copy
-      }
-
       spyOn(Date.prototype, 'getTime').and.callFake(function () {
         counter += 1
         return counter
@@ -270,8 +262,8 @@ describe('jasmine adapter', function () {
         expect(result.time).toBe(1) // 4 - 3
       })
 
-      reporter.specStarted(copySpecResult())
-      reporter.specDone(copySpecResult())
+      reporter.specStarted(Object.assign({}, spec.result))
+      reporter.specDone(Object.assign({}, spec.result))
 
       expect(karma.result).toHaveBeenCalled()
     })

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -253,6 +253,14 @@ describe('jasmine adapter', function () {
     it('should report time for every spec', function () {
       var counter = 3
 
+      function copySpecResult() {
+        var copy = {}
+        for(var i in spec.result) {
+          copy[i] = spec.result[i]
+        }
+        return copy
+      }
+
       spyOn(Date.prototype, 'getTime').and.callFake(function () {
         counter += 1
         return counter
@@ -262,8 +270,8 @@ describe('jasmine adapter', function () {
         expect(result.time).toBe(1) // 4 - 3
       })
 
-      reporter.specStarted(spec.result)
-      reporter.specDone(spec.result)
+      reporter.specStarted(copySpecResult())
+      reporter.specDone(copySpecResult())
 
       expect(karma.result).toHaveBeenCalled()
     })


### PR DESCRIPTION
Time reporting broke since jasmine-core v2.9 because the reporter API
now receives copies of spec results instead of the real deal.
We cannot rely on the same object being passed around.

Fixes #196 