### PR TITLE
adapter.js: Include full name of spec in specDone()

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -232,6 +232,7 @@ function KarmaReporter (tc, jasmineEnv) {
     var skipped = specResult.status === 'disabled' || specResult.status === 'pending' || specResult.status === 'excluded'
 
     var result = {
+      fullName: specResult.fullName,
       description: specResult.description,
       id: specResult.id,
       log: [],

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -87,6 +87,7 @@ describe('jasmine adapter', function () {
       karma.result.and.callFake(function (result) {
         expect(result.id).toBe(spec.id)
         expect(result.description).toBe('contains spec with an expectation')
+        expect(result.fullName).toBe('A suite contains spec with an expectation')
         expect(result.suite).toEqual(['Parent Suite', 'Child Suite'])
         expect(result.success).toBe(true)
         expect(result.skipped).toBe(false)


### PR DESCRIPTION
This commit appends the field 'fullName' to the result sent back to the
Karma server. The full name is useful to identify the exact spec that
was run.

API for specResult: https://jasmine.github.io/api/2.9/global.html#SpecResult