### PR TITLE
Update the version to 2.0.0 and restrict node version available to 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4.0"
   - "5.0"
+  - "6.13"
+  - "8.10"
   - "stable"
 
 # Make sure we have new NPM.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - "4.0"
-  - "5.0"
-  - "6.13"
-  - "8.10"
+  - "6.0"
+  - "8.0"
   - "stable"
 
 # Make sure we have new NPM.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jasmine",
-  "version": "2.0.0",
+  "version": "1.1.1",
   "description": "A Karma plugin - adapter for Jasmine testing framework.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jasmine",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A Karma plugin - adapter for Jasmine testing framework.",
   "main": "lib/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "grunt-karma": "2.x",
     "grunt-npm": "0.0.2",
     "jasmine-core": "~2.4.1",
-    "karma": "1.x || ",
+    "karma": "2.x || ",
     "karma-chrome-launcher": "1.x || ~0.2.2",
     "karma-firefox-launcher": "1.x || ~0.1.7",
     "load-grunt-tasks": "^3.4.1"
@@ -37,6 +37,9 @@
   "peerDependencies": {
     "jasmine-core": "*",
     "karma": "*"
+  },
+  "engines": {
+    "node": ">= 4"
   },
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
In this patch The version is bumped to 2.0.0, because it removes the support for node < 4.
Added tests for node version 6 and 8 as well