### PR TITLE
--grep option now supports real regular expressions but not masks only.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -300,13 +300,27 @@ var getGrepOption = function (clientArguments) {
   }
 }
 
+var createRegExp = function (filter) {
+  if ("" === (filter || ""))
+    return new RegExp(); // to match all
+
+  var regExp = /^[/](.*)[/]([gmixXsuUAJD]*)$/; // pattern to check whether the string is RegExp pattern
+
+  var parts = regExp.exec(filter);
+  if (parts === null)
+    return new RegExp(filter.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')); // escape functional symbols
+
+  var patternExpression = parts[1];
+  var patternSwitches = parts[2];
+  return new RegExp(patternExpression, patternSwitches);
+}
+
 /**
  * Create jasmine spec filter
  * @param {Object} options Spec filter options
  */
 var KarmaSpecFilter = function (options) {
-  var filterString = options && options.filterString() && options.filterString().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
-  var filterPattern = new RegExp(filterString)
+  var filterPattern = createRegExp(options && options.filterString())
 
   this.matches = function (specName) {
     return filterPattern.test(specName)

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -481,7 +481,72 @@ describe('jasmine adapter', function () {
     })
   })
 
-  describe('KarmaSpecFilter', function () {
+  describe("createRegExp", function () {
+    it ("should match all string by null pattern", function() {
+      var regExp = createRegExp(null);
+
+      expect(regExp.test(null)).toEqual(true);
+      expect(regExp.test("bar")).toEqual(true);
+      expect(regExp.test("test")).toEqual(true);
+      expect(regExp.test("test.asfsdf.sdfgfdh")).toEqual(true);
+    });
+
+    it ("should match all string by empty pattern", function() {
+      var regExp = createRegExp("");
+
+      expect(regExp.test(null)).toEqual(true);
+      expect(regExp.test("bar")).toEqual(true);
+      expect(regExp.test("test")).toEqual(true);
+      expect(regExp.test("test.asfsdf.sdfgfdh")).toEqual(true);
+    });
+
+    it ("should match strings by pattern with flags", function() {
+      var regExp = createRegExp("/test.*/i");
+      expect(regExp.test(null)).toEqual(false);
+      expect(regExp.test("bar")).toEqual(false);
+      expect(regExp.test("test")).toEqual(true);
+      expect(regExp.test("test.asfsdf.sdfgfdh")).toEqual(true);
+    })
+
+    it ("should match strings by pattern without flags", function() {
+      var regExp = createRegExp("/test.*/");
+      expect(regExp.test(null)).toEqual(false);
+      expect(regExp.test("bar")).toEqual(false);
+      expect(regExp.test("test")).toEqual(true);
+      expect(regExp.test("test.asfsdf.sdfgfdh")).toEqual(true);
+    })
+
+    it ("should match strings by complex pattern", function() {
+      var regExp = createRegExp("/test.*[/]i/i");
+      expect(regExp.test(null)).toEqual(false);
+      expect(regExp.test("bar")).toEqual(false);
+      expect(regExp.test("test")).toEqual(false);
+      expect(regExp.test("test/i")).toEqual(true);
+    })
+  })
+
+  describe('KarmaSpecFilter(RegExp)', function () {
+    var specFilter
+
+    beforeEach(function () {
+      specFilter = new KarmaSpecFilter({
+        filterString: function () {
+          return '/test.*/'
+        }
+      })
+    })
+
+    it('should create spec filter', function () {
+      expect(specFilter).toBeDefined()
+    })
+
+    it('should filter spec by name', function () {
+      expect(specFilter.matches('bar')).toEqual(false)
+      expect(specFilter.matches('test')).toEqual(true)
+    })
+  })
+
+  describe('KarmaSpecFilter(non-RegExp)', function () {
     var specFilter
 
     beforeEach(function () {


### PR DESCRIPTION
To use real regular expressions, use the traditional JavaScript syntax:
> karma run -- --grep=/<regex>/<flags>
Sample:
> karma run -- --grep=/.*should.*/i

This implementation only expands the functionality without breaking the existing syntax.
You can continue to use the old syntax:
> karma run -- --grep=RootTestSuite