### PR TITLE
fix: return false for every entry is irrelevant

### DIFF
--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -465,6 +465,7 @@ describe('jasmine adapter', function () {
     })
 
     it('should return the all stack entries if every entry is irrelevant', function () {
+      // Check the case where the filteredStack is empty
       spyOn(window, 'isExternalStackEntry').and.returnValue(false)
       expect(getRelevantStackFrom('a\nb\nc')).toEqual(['a', 'b', 'c'])
     })

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -465,7 +465,7 @@ describe('jasmine adapter', function () {
     })
 
     it('should return the all stack entries if every entry is irrelevant', function () {
-      spyOn(window, 'isExternalStackEntry').and.returnValue(true)
+      spyOn(window, 'isExternalStackEntry').and.returnValue(false)
       expect(getRelevantStackFrom('a\nb\nc')).toEqual(['a', 'b', 'c'])
     })
 


### PR DESCRIPTION
I fix return value for matching spec (`should return the all stack entries if every entry is irrelevant`).