### PR TITLE
Add failedExpectations to the karma result object

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -242,7 +242,8 @@ function KarmaReporter (tc, jasmineEnv) {
       success: specResult.failedExpectations.length === 0,
       suite: [],
       time: skipped ? 0 : new _Date().getTime() - startTimeCurrentSpec,
-      executedExpectationsCount: specResult.failedExpectations.length + specResult.passedExpectations.length
+      executedExpectationsCount: specResult.failedExpectations.length + specResult.passedExpectations.length,
+      failedExpectations: specResult.failedExpectations
     }
 
     // generate ordered list of (nested) suite names


### PR DESCRIPTION
I am adding this proposal because I am currently building a karma reporter and I can't get access to the `failedExpectations` in order to make a better printing for the expects.