### PR TITLE
Bind jasmineEnv to configuration setters

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -367,8 +367,9 @@ function createStartFn (karma, jasmineEnv) {
     jasmineEnv.execute()
   }
 
-  function setOption (option, set) {
-    if (option != null && typeof set === 'function') {
+  function setOption (option, setter) {
+    if (option != null && typeof setter === 'function') {
+      var set = setter.bind(jasmineEnv)
       set(option)
     }
   }


### PR DESCRIPTION
Since jasmine@3.3.0, all jasmine single method configurations calls to `this.deprecated` primarily to print a deprecation warning. Those single method configuration should be called with an appropriate `this`, which would be the jasmineEnv.

Resolves #221 