### PR TITLE
Handle Jasmine 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ module.exports = function(config) {
       jasmine: {
         random: true,
         seed: '4321',
-        stopOnFailure: true,
+        oneFailurePerSpec: true,
         failFast: true,
         timeoutInterval: 1000
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4280,9 +4280,9 @@
       "optional": true
     },
     "jasmine-core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.0.0.tgz",
-      "integrity": "sha1-jNsgzzNrG4aDDtxYsaiqxHRV6Uw=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.3.0.tgz",
+      "integrity": "sha512-3/xSmG/d35hf80BEN66Y6g9Ca5l/Isdeg/j6zvbTYlTzeKinzmaTM4p9am5kYqOmE05D7s1t8FGjzdSnbUbceA==",
       "dev": true
     },
     "js-yaml": {

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "grunt-karma": "2.x",
     "grunt-npm": "0.0.2",
     "karma": "2.x || ",
-    "jasmine-core": "~3.0.0",
+    "jasmine-core": "^3.3.0",
     "karma-chrome-launcher": "1.x || ~0.2.2",
     "karma-firefox-launcher": "1.x || ~0.1.7",
     "load-grunt-tasks": "^3.4.1"
   },
   "peerDependencies": {
-    "jasmine-core": "*",
+    "jasmine-core": "^3.3.0",
     "karma": "*"
   },
   "engines": {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -322,19 +322,26 @@ var KarmaSpecFilter = function (options) {
 }
 
 /**
+ * Configure jasmine specFilter
+ *
+ * This function is invoked from the wrapper.
+ * @see  adapter.wrapper
+ *
  * @param {Object} config The karma config
  * @param {Object} jasmineEnv jasmine environment object
  */
 var createSpecFilter = function (config, jasmineEnv) {
-  var specFilter = new KarmaSpecFilter({
+  var karmaSpecFilter = new KarmaSpecFilter({
     filterString: function () {
       return getGrepOption(config.args)
     }
   })
 
-  jasmineEnv.specFilter = function (spec) {
-    return specFilter.matches(spec.getFullName())
+  var specFilter = function (spec) {
+    return karmaSpecFilter.matches(spec.getFullName())
   }
+
+  jasmineEnv.configure({ specFilter: specFilter })
 }
 
 /**
@@ -355,22 +362,13 @@ function createStartFn (karma, jasmineEnv) {
 
     jasmineEnv = jasmineEnv || window.jasmine.getEnv()
 
-    setOption(jasmineConfig.stopOnFailure, jasmineEnv.throwOnExpectationFailure)
-    setOption(jasmineConfig.failFast, jasmineEnv.stopOnSpecFailure)
-    setOption(jasmineConfig.seed, jasmineEnv.seed)
-    setOption(jasmineConfig.random, jasmineEnv.randomizeTests)
+    jasmineEnv.configure(jasmineConfig)
 
     window.jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmineConfig.timeoutInterval ||
        window.jasmine.DEFAULT_TIMEOUT_INTERVAL
 
     jasmineEnv.addReporter(new KarmaReporter(karma, jasmineEnv))
     jasmineEnv.execute()
-  }
-
-  function setOption (option, set) {
-    if (option != null && typeof set === 'function') {
-      set(option)
-    }
   }
 }
 


### PR DESCRIPTION
Manually tested, and confirmed to work with Jasmine@3.0.0 and Jasmine@3.3.0.

Resolves #221

Needs:
- A way to automate testing in the different versions of Jasmine
