### PR TITLE
fix(console): Re-add Error: to the stack

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -70,6 +70,7 @@ function formatFailedStep (step) {
   // Remove the message prior to processing the stack to prevent issues like
   // https://github.com/karma-runner/karma-jasmine/issues/79
   var stack = step.stack.replace('Error: ' + step.message, '')
+  var prefix = (stack === step.stack) ? '' : 'Error: '
 
   var dirtyRelevantStack = getRelevantStackFrom(stack)
 
@@ -85,14 +86,14 @@ function formatFailedStep (step) {
     } else {
       // Stack entry is already in the message,
       // we consider it to be a suitable message alternative:
-      relevantMessage.push(dirtyRelevantStack[i])
+      relevantMessage.push(prefix + dirtyRelevantStack[i])
     }
   }
 
   // In most cases the above will leave us with an empty message...
   if (relevantMessage.length === 0) {
     // Let's reuse the original message:
-    relevantMessage.push(step.message)
+    relevantMessage.push(prefix + step.message)
 
     // Now we probably have a repetition case where:
     // relevantMessage: ["Expected true to be false."]

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -203,7 +203,7 @@ describe('jasmine adapter', function () {
 
       karma.result.and.callFake(function (result) {
         expect(result.log).toEqual([
-          'Expected true to be false.\n' +
+          'Error: Expected true to be false.\n' +
           '    at /foo/bar/baz.spec.js:23:29\n' +
           '    at /foo/bar/baz.js:18:20'
         ])
@@ -229,7 +229,7 @@ describe('jasmine adapter', function () {
 
       karma.result.and.callFake(function (result) {
         expect(result.log).toEqual([
-          'Expected true to be false.\n' +
+          'Error: Expected true to be false.\n' +
           '    at stack (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1441:17)\n' +
           '    at buildExpectationResult (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1411:14)\n' +
           '    at Spec.Env.expectationResultFactory (/foo/bar/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:533:18)\n' +


### PR DESCRIPTION
Chrome devtools looks for a pattern in stack traces and if it finds a match
it will shorten and linkify the stack, and apply sourcemaps. The pattern fails
when the "Error: " is removed. So we put it back for debugging's sake.