### PR TITLE
Configuration in createStartFn now happens outside the returned startFn

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -356,18 +356,18 @@ var createSpecFilter = function (config, jasmineEnv) {
  * @return {Function}              Karma starter function.
  */
 function createStartFn (karma, jasmineEnv) {
+  var clientConfig = karma.config || {}
+  var jasmineConfig = clientConfig.jasmine || {}
+
+  jasmineEnv = jasmineEnv || window.jasmine.getEnv()
+
+  jasmineEnv.configure(jasmineConfig)
+
+  window.jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmineConfig.timeoutInterval ||
+    window.jasmine.DEFAULT_TIMEOUT_INTERVAL
+
   // This function will be assigned to `window.__karma__.start`:
   return function () {
-    var clientConfig = karma.config || {}
-    var jasmineConfig = clientConfig.jasmine || {}
-
-    jasmineEnv = jasmineEnv || window.jasmine.getEnv()
-
-    jasmineEnv.configure(jasmineConfig)
-
-    window.jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmineConfig.timeoutInterval ||
-       window.jasmine.DEFAULT_TIMEOUT_INTERVAL
-
     jasmineEnv.addReporter(new KarmaReporter(karma, jasmineEnv))
     jasmineEnv.execute()
   }


### PR DESCRIPTION
Should fix [issue#218](https://github.com/karma-runner/karma-jasmine/issues/218). Sadly I'm having a hard time understanding the project, so the fix is as minimal as possible and no refactoring was done.

The commit merely moves up the configuration in `createStartFn()`, so that it happens as soon as `createStartFn()` is called. Before this commit, the configuration was only performed, once `window.__karma__.start()` was called.