### PR TITLE
On error in beforeAll/afterAll relevant information to debug are miss…

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -60,12 +60,23 @@ function getRelevantStackFrom (stack) {
  * @return {String}      Formatted step.
  */
 function formatFailedStep (step) {
-  // Safari seems to have no stack trace,
-  // so we just return the error message:
-  if (!step.stack) { return step.message }
-
   var relevantMessage = []
   var relevantStack = []
+
+  // Safari/Firefox seems to have no stack trace,
+  // so we just return the error message and if available
+  // construct a stacktrace out of filename and lineno:
+  if (!step.stack) {
+    if (step.filename) {
+      let stack = step.filename;
+      if (step.lineno) {
+        stack = stack + ':' + step.lineno;
+      }
+      relevantStack.push(stack);
+    }
+    relevantMessage.push(step.message);
+    return relevantMessage.concat(relevantStack).join('\n');
+  }
 
   // Remove the message prior to processing the stack to prevent issues like
   // https://github.com/karma-runner/karma-jasmine/issues/79

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -68,11 +68,11 @@ function formatFailedStep (step) {
   // construct a stacktrace out of filename and lineno:
   if (!step.stack) {
     if (step.filename) {
-      let stack = step.filename
+      let stackframe = step.filename
       if (step.lineno) {
-        stack = stack + ':' + step.lineno
+        stackframe = stackframe + ':' + step.lineno
       }
-      relevantStack.push(stack)
+      relevantStack.push(stackframe)
     }
     relevantMessage.push(step.message)
     return relevantMessage.concat(relevantStack).join('\n')

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -68,14 +68,14 @@ function formatFailedStep (step) {
   // construct a stacktrace out of filename and lineno:
   if (!step.stack) {
     if (step.filename) {
-      let stack = step.filename;
+      let stack = step.filename
       if (step.lineno) {
-        stack = stack + ':' + step.lineno;
+        stack = stack + ':' + step.lineno
       }
-      relevantStack.push(stack);
+      relevantStack.push(stack)
     }
-    relevantMessage.push(step.message);
-    return relevantMessage.concat(relevantStack).join('\n');
+    relevantMessage.push(step.message)
+    return relevantMessage.concat(relevantStack).join('\n')
   }
 
   // Remove the message prior to processing the stack to prevent issues like

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -335,6 +335,16 @@ describe('jasmine adapter', function () {
       expect(formatFailedStep(step)).toBe('MESSAGE')
     })
 
+    it('should report message, filename and linenumber if no stack trace but filename and lineno', function () {
+      var step = {
+        passed: false,
+        lineno: 45,
+        filename: 'source/controller.js',
+        message: 'MESSAGE'
+      }
+
+      expect(formatFailedStep(step)).toBe('MESSAGE\nsource/controller.js:45')
+    })
     it('should properly format message containing new-line characters', function () {
       // FF does not have the message in the stack trace
 


### PR DESCRIPTION
…ing.

e.g. on Firefox no stack is available, but it can be one constructed if filename and
lineno are available.