### PR TITLE
feat(adapter): handle new Jasmine optional behavior for specs without expectations

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -271,6 +271,12 @@ function KarmaReporter (tc, jasmineEnv) {
       }
     }
 
+    // When failSpecWithNoExpectations is true, Jasmine will report specs without expectations as failed
+    if (result.executedExpectationsCount === 0 && specResult.status === 'failed') {
+      result.success = false
+      result.log.push('Spec has no expectations')
+    }
+
     tc.result(result)
     delete specResult.startTime
   }

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -137,6 +137,7 @@ describe('jasmine adapter', function () {
 
     it('should report executedExpectCount 0 if no expectations', function () {
       karma.result.and.callFake(function (result) {
+        expect(result.success).toBe(true)
         expect(result.executedExpectationsCount).toBe(0)
       })
 
@@ -156,6 +157,24 @@ describe('jasmine adapter', function () {
       reporter.specDone(spec.result)
 
       expect(karma.result).toHaveBeenCalled()
+    })
+
+    describe('when spec status is failed and no expect() calls ran', function () {
+      it('should report fail result and log a message', function () {
+        karma.result.and.callFake(function (result) {
+          expect(result.success).toBe(false)
+          expect(result.log.length).toBe(1)
+          expect(result.executedExpectationsCount).toBe(0)
+        })
+
+        spec.result.status = 'failed'
+        spec.result.failedExpectations = []
+        spec.result.passedExpectations = []
+
+        reporter.specDone(spec.result)
+
+        expect(karma.result).toHaveBeenCalled()
+      })
     })
 
     it('should report errors in afterAll blocks', function () {


### PR DESCRIPTION
In the next version of Jasmine, a new configuration option `failSpecWithNoExpectations` will be added. If turned ON, Jasmine will be reporting specs that have not run any expectations as `failed` Subsequently, this change is to update the adapter for such scenario.

See [the corresponding feature request in Jasmine](https://github.com/jasmine/jasmine/issues/1740). Please don't mind the Closed status of the Issue/PR, and see [from the pull request comments and history](https://github.com/jasmine/jasmine/pull/1743) that the feature has already been implemented/merged into Jasmine. The status is Closed because the owner merged and closed it manually.