### PR TITLE
Fixed so that timing will always use native Date for rare cases

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -2,6 +2,10 @@
 
 'use strict'
 
+// Save link to native Date object
+// before it might be mocked by the user
+var _Date = Date
+
 /**
  * Decision maker for whether a stack entry is considered external to jasmine and karma.
  * @param  {String}  entry Error stack entry.
@@ -142,9 +146,6 @@ function getAllSpecNames (topSuite) {
 function KarmaReporter (tc, jasmineEnv) {
   var currentSuite = new SuiteNode()
 
-  // Save link on native Date object
-  // because user can mock it
-  var _Date = Date
   var startTimeCurrentSpec = new _Date().getTime()
 
   function handleGlobalErrors (result) {


### PR DESCRIPTION
Since the user might mock Dates in tests, KarmaReporter saves a reference to the native Date and uses that reference for measuring duration. The problem is that it only works when users follows best practises when writing tests. 

If a user writes a "bad" test where the Date is mocked in the body of a `decribe` instead of inside an `it` or `beforeEach`, the Date is already mocked by the time KarmaReporter is called.

By saving the reference at the time adapter.js is executed instead of when KarmaReporter is called, this problem is prevented.

**Nothing prevents a developer from writing:**
```javascript
describe('foo', function () {
    jasmine.clock().mockDate(new Date(0));
    it('bar', function () {
    });
}
```
Before the change in this PR, a test like the one above would cause the duration of the test to be reported incorrectly. If the time is reported as negative, then all sorts of thouble can happen down the line. 

We ran into issues where a report file generated by karma-sonarqube-unit-reporter containing 4500+ tests was ignored by Sonarqube because a duration in the xml was negative.