### PR TITLE
chore: Tweak Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,17 @@
-sudo: false
-# the xvfb service syntax depends on distro
-dist: xenial
 language: node_js
+
 node_js:
   - "8"
   - "10"
-
-# Make sure we have new NPM.
-before_install:
-  - if [[ "`node --version`" = v0* ]] || [[ "`node --version`" = v4* ]]; then npm install -g npm@latest-3; fi
+  - "12"
 
 services:
   - xvfb
 
 before_script:
   - export DISPLAY=:99.0
-  - npm install -g grunt-cli
 
 script:
-  - grunt
-  - ./integration-tests.sh
+  - grunt && ./integration-tests.sh
+
+cache: npm


### PR DESCRIPTION
* remove the obsolete `sudo: false`
* remove the `dist` property; xenial is the default
* remove the obsolete npm update step
* stop installing grunt-cli since it's already available
* add the explicit `cache: npm`
* combine the test scripts so that if the first fails the whole build will fail