### PR TITLE
fix(filter): match any portion of a spec name

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -340,7 +340,7 @@ function getId (s) {
 
 function getSpecsByName (specs, name) {
   specs = specs.filter(function (s) {
-    return s.name === name
+    return s.name.indexOf(name) !== -1
   })
   if (specs.length === 0) {
     throw new Error('No spec found with name: "' + name + '"')

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -594,6 +594,11 @@ describe('jasmine adapter', function () {
         var actualSpecs = getDebugSpecToRun(location, specs)
         expect(actualSpecs).toEqual([mockSpecTest])
       })
+      it('should match with param containing only a prefix', function () {
+        var location = { search: '?spec=te' }
+        var actualSpecs = getDebugSpecToRun(location, specs)
+        expect(actualSpecs).toEqual([mockSpecTest])
+      })
       it('should throw with param spec not found', function () {
         var location = { search: '?spec=oops' }
         expect(function () {


### PR DESCRIPTION
jasmine tests are named suite-name + spec-name. The links printed by
karma-jasmine-html-reporter include links for suite-name (only). To support
running the suite, allow the filter to match any part of the test name.

Fixes #256 