### PR TITLE
fix(filter): match ONLY START portion of a spec name

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -350,7 +350,7 @@ function getId (s) {
 
 function getSpecsByName (specs, name) {
   specs = specs.filter(function (s) {
-    return s.name.indexOf(name) !== -1
+    return s.name.startsWith(name)
   })
   if (specs.length === 0) {
     throw new Error('No spec found with name: "' + name + '"')


### PR DESCRIPTION
jasmine tests are named suite-name + spec-name. The links printed by
karma-jasmine-html-reporter include links for suite-name (only). To support
running the suite, allow the filter to match **ONLY the START portion** of the test name.
Fixes #256 #270