### PR TITLE
Remove `Order.sort` function passing to Karma callback

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -191,8 +191,22 @@ function KarmaReporter (tc, jasmineEnv) {
     // Any errors in top-level afterAll blocks are given here.
     handleGlobalErrors(result)
 
+    // Remove functions from called back results to avoid IPC errors in Electron
+    // https://github.com/twolfson/karma-electron/issues/47
+    var cleanedOrder
+    if (result.order) {
+      cleanedOrder = {}
+      var orderKeys = Object.getOwnPropertyNames(result.order)
+      for (var i = 0; i < orderKeys.length; i++) {
+        var orderKey = orderKeys[i]
+        if (typeof result.order[orderKey] !== 'function') {
+          cleanedOrder[orderKey] = result.order[orderKey]
+        }
+      }
+    }
+
     tc.complete({
-      order: result.order,
+      order: cleanedOrder,
       coverage: window.__coverage__
     })
   }


### PR DESCRIPTION
We received a bug report in `karma-electron`, https://github.com/twolfson/karma-electron/issues/47, which eventually traced back to Electron being unable to pass a `function` to between Karma contexts due to IPC fixing passing references between processes

This PR resolve that bug by removing the `function` which was being attempted to pass as a reference between processes

In this PR:

- Remove `Order.sort` function passing to Karma callback
- Fixes https://github.com/twolfson/karma-electron/issues/47

Feel free to request commit message changes (or apply them yourself). I tried to find documentation on them but was running out of time =/