### PR TITLE
fix(adapter): bind the timeout to the config at file-load

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -495,19 +495,21 @@ var createSpecFilter = function (config, jasmineEnv) {
  * @return {Function}              Karma starter function.
  */
 function createStartFn (karma, jasmineEnv) {
+  var clientConfig = karma.config || {}
+  var jasmineConfig = clientConfig.jasmine || {}
+  // Changes to jasmine global values need to happen before the file-scope
+  // code in a test is executed (describe functions)
+  window.jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmineConfig.timeoutInterval ||
+    window.jasmine.DEFAULT_TIMEOUT_INTERVAL
+
   // This function will be assigned to `window.__karma__.start`:
   return function () {
-    var clientConfig = karma.config || {}
-    var jasmineConfig = clientConfig.jasmine || {}
-
     jasmineEnv = jasmineEnv || window.jasmine.getEnv()
 
     jasmineConfig.specFilter = createSpecFilter(clientConfig, jasmineEnv)
 
     jasmineEnv.configure(jasmineConfig)
 
-    window.jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmineConfig.timeoutInterval ||
-      window.jasmine.DEFAULT_TIMEOUT_INTERVAL
     jasmineEnv.addReporter(new KarmaReporter(karma, jasmineEnv))
     jasmineEnv.execute()
   }

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -429,7 +429,9 @@ describe('jasmine adapter', function () {
 
       jasmineConfig.timeoutInterval = 10000
 
-      createStartFn(tc, jasmineEnv)()
+      // Create the __start__ function but do not call it (simulate JS file scope
+      // execution but not load event handling)
+      createStartFn(tc, jasmineEnv)
 
       expect(jasmine.DEFAULT_TIMEOUT_INTERVAL).toBe(jasmineConfig.timeoutInterval)
 


### PR DESCRIPTION
Jasmine tests are defined during load (describe calls). The timeout is bound into the first test at that
time. Set the default to the config value during file load rather than during load-handling.