### PR TITLE
feat(spec-filter): allow custom specFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ run a subset of the full set of specs. Complete sharding support needs to be
 done in the process that calls karma, and would need to support test result
 integration across shards.
 
+## Custom spec filter
+
+Providing a [custom spec filter](https://jasmine.github.io/api/edge/Configuration#specFilter) is also supported.
+
+Example:
+
+```js
+// Users are able to set a custom specFilter themselves
+
+jasmine.getEnv().configure({
+  specFilter: function (spec) {
+    return spec.getFullName() === 'spec that succeeds'
+  }
+})
+
+describe('spec', () => {
+  it('that fails', () => {
+    fail('This spec should not run!')
+  })
+
+  it('that succeeds', () => {
+    expect(1).toBe(1)
+  })
+})
+```
+
 ---
 
 For more information on Karma see the [homepage](https://karma-runner.github.io/).

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -476,8 +476,9 @@ var KarmaSpecFilter = function (clientConfig, jasmineEnv) {
 var createSpecFilter = function (config, jasmineEnv) {
   var karmaSpecFilter = new KarmaSpecFilter(config, jasmineEnv)
 
+  var originalSpecFilter = jasmineEnv.configuration().specFilter
   var specFilter = function (spec) {
-    return karmaSpecFilter.matches(spec)
+    return originalSpecFilter(spec) && karmaSpecFilter.matches(spec)
   }
 
   return specFilter
@@ -502,7 +503,6 @@ function createStartFn (karma, jasmineEnv) {
     jasmineEnv = jasmineEnv || window.jasmine.getEnv()
 
     jasmineConfig.specFilter = createSpecFilter(clientConfig, jasmineEnv)
-
     jasmineEnv.configure(jasmineConfig)
 
     window.jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmineConfig.timeoutInterval ||

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -572,17 +572,21 @@ describe('jasmine adapter', function () {
         name: 'test',
         id: 1
       }
+      var mockConfiguration = {
+        specFilter: jasmine.createSpy().and.returnValue(true)
+      }
       mockJasmineEnv = {
         topSuite: () => {
           return {
             children: [mockSpecTest, mockSpecBar]
           }
-        }
+        },
+        configuration: () => mockConfiguration
       }
       specs = mockJasmineEnv.topSuite().children
     })
 
-    describe(' getGrepSpecsToRun', function () {
+    describe('getGrepSpecsToRun', function () {
       it('should not match without grep arg', function () {
         var karmaConfMock = {
           args: []
@@ -659,6 +663,16 @@ describe('jasmine adapter', function () {
 
         expect(specFilter(mockSpecTest)).toEqual(true)
         expect(specFilter(mockSpecBar)).toEqual(false)
+      })
+      it('should still allow a custom spec filter', function () {
+        var karmaConfMock = {}
+        mockJasmineEnv.configuration().specFilter.and.returnValue(false)
+        var specFilter = createSpecFilter(karmaConfMock, mockJasmineEnv)
+        expect(specFilter(mockSpecTest)).toEqual(false)
+        expect(specFilter(mockSpecBar)).toEqual(false)
+        expect(mockJasmineEnv.configuration().specFilter).toHaveBeenCalledTimes(2)
+        expect(mockJasmineEnv.configuration().specFilter).toHaveBeenCalledWith(mockSpecTest)
+        expect(mockJasmineEnv.configuration().specFilter).toHaveBeenCalledWith(mockSpecBar)
       })
     })
   })

--- a/test/fixtures/custom-filter/karma.conf.js
+++ b/test/fixtures/custom-filter/karma.conf.js
@@ -1,0 +1,18 @@
+module.exports = function (config) {
+  config.set({
+    frameworks: ['jasmine'],
+    reporters: ['karma-jasmine'],
+
+    files: ['test/*.js'],
+
+    browsers: process.env.TRAVIS ? ['Firefox'] : ['Chrome'],
+
+    autoWatch: true,
+
+    plugins: [
+      'karma-firefox-launcher',
+      'karma-chrome-launcher',
+      require.resolve('../../../')
+    ]
+  })
+}

--- a/test/fixtures/custom-filter/test/custom-filter.spec.js
+++ b/test/fixtures/custom-filter/test/custom-filter.spec.js
@@ -1,0 +1,18 @@
+// Users are able to set a custom specFilter themselves
+// karma-jasmine will allow them to do so.
+
+jasmine.getEnv().configure({
+  specFilter: function (spec) {
+    return spec.getFullName() !== 'spec that fails'
+  }
+})
+
+describe('spec', () => {
+  it('that fails', () => {
+    fail('This spec should not run!')
+  })
+
+  it('that succeeds', () => {
+    expect(1).toBe(1)
+  })
+})


### PR DESCRIPTION
Allow users to define their own jasmine `specFilter`.

```js
jasmine.getEnv().configure({
  specFilter: function(spec) {
    // ...
  }
})
```

Fixes #273