### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -348,7 +348,7 @@ function getGrepSpecsToRun (clientConfig, specs) {
 function parseQueryParams (location) {
   var params = {}
   if (location && Object.prototype.hasOwnProperty.call(location, 'search')) {
-    var pairs = location.search.substr(1).split('&')
+    var pairs = location.search.slice(1).split('&')
     for (var i = 0; i < pairs.length; i++) {
       var keyValue = pairs[i].split('=')
       params[decodeURIComponent(keyValue[0])] =


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.