### PR TITLE
fix: fixes matches performance issue, github#302

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -457,11 +457,10 @@ var KarmaSpecFilter = function (clientConfig, jasmineEnv) {
           specs
   }
 
-  this.specIdsToRun =
-    getSpecsToRun(window.location, clientConfig, jasmineEnv).map(getId)
+  this.specIdsToRun = new Set(getSpecsToRun(window.location, clientConfig, jasmineEnv).map(getId))
 
   this.matches = function (spec) {
-    return this.specIdsToRun.indexOf(spec.id) !== -1
+    return this.specIdsToRun.has(spec.id)
   }
 }
 


### PR DESCRIPTION
improve this.matches function performance by converting indexof loop to Set (hashtable) has. O(n) to O(1) fixes: https://github.com/karma-runner/karma-jasmine/issues/302