### PR TITLE
Don't log debug URLs for tests that are skipped

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ initJasmine.$inject = ['config.files']
 function InjectKarmaJasmineReporter (singleRun) {
   return {
     onSpecComplete (browser, karmaResult) {
-      if (!singleRun && karmaResult.debug_url) {
+      if (!singleRun && !karmaResult.skipped && karmaResult.debug_url) {
         console.log('Debug this test: ' + karmaResult.debug_url)
       }
     }


### PR DESCRIPTION
Via `pending()`